### PR TITLE
GitHub workflow 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,9 +52,7 @@ module.exports = {
     'react/no-unescaped-entities': 'off',
     'react/forbid-dom-props': 'off',
     'react/prop-types': 'off',
-    // 'react/jsx-no-bind': 'warn',
-
-    camelcase: 'warn',
+    camelcase: 'off',
     'id-match': 'warn',
     'max-classes-per-file': 'off',
     'no-underscore-dangle': 'off',
@@ -111,7 +109,6 @@ module.exports = {
     'prefer-arrow-callback': ['error', { allowNamedFunctions: true }],
     'func-style': ['error', 'expression', { allowArrowFunctions: true }],
     'no-multiple-empty-lines': [1, { max: 1, maxEOF: 0 }],
-    // 'react/react-in-jsx-scope': 'off',
     'import/namespace': [
       'error',
       {

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -20,10 +20,10 @@ jobs:
       run: yarn build
 
     - name: Copy files via scp
-      uses: appleboy/scp-action@master              
+      uses: appleboy/ssh-action@master              
       with:
         host: ${{ secrets.HOST_SERVER }}
         username: ${{ secrets.SERVER_ADMIN }}
         password: ${{ secrets.SERVER_ADMIN_PW }}
-        source: "-r ./build/."
-        target: ${{ secrets.DEV_WEB_SERVER_LOCATION }}
+        script: |
+                scp -r /build/. root@${{ secrets.HOST_SERVER }}:${{ secrets.DEV_WEB_SERVER_LOCATION }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -28,7 +28,7 @@ jobs:
       uses: appleboy/scp-action@master              
       with:
         host: ${{ secrets.HOST_SERVER }}
-        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        username: ${{ secrets.USERNAME }}
         passphrase: ${{ secrets.PASSPHRASE }}
         source: "./build"
         target: ${{ secrets.DEV_WEB_SERVER_LOCATION }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -32,4 +32,4 @@ jobs:
         key: ${{ secrets.SSH_PRIVATE_KEY }}
         passphrase: ${{ secrets.SSH_PASSPHRASE }}
         source: "./build/*"
-        target: /var/www/tcimpidis/dev/public_html
+        target: /var/www/tcimpidis/dev/public_html/

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -12,7 +12,7 @@ env:
   SSH_AUTH_SOCK: /tmp/ssh_agent.sock
 
 jobs:
-  Build with SSH:
+  Build_with_SSH:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -23,8 +23,8 @@ jobs:
       uses: appleboy/ssh-action@master              
       with:
         host: ${{ secrets.HOST_SERVER }}
-        username: ${{ secrets.USERNAME }}
-        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        username: ${{ secrets.SERVER_ADMIN }}
+        password: ${{ secrets.SERVER_ADMIN_PW }}
         passphrase: ${{ secrets.SSH_PASSPHRASE }}
         script: |
-                scp -i ${{ env.SSH_AUTH_SOCK }} -r /build/. root@${{ secrets.HOST_SERVER }}:${{ secrets.DEV_WEB_SERVER_LOCATION }}
+                scp -r /build/. root@${{ secrets.HOST_SERVER }}:${{ secrets.DEV_WEB_SERVER_LOCATION }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -4,22 +4,40 @@ on:
   push: 
     branches:
       - development
+      - github_worflow_fired_and_failed
 
+env:
+  # Use the same ssh-agent socket value across all jobs
+  # Useful when a GH action is using SSH behind-the-scenes
+  SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+s
 jobs:
-  deploy:
+  job1:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/development' 
+
     steps:
-      - name: Deploying to Digitalocean droplet
-        uses: appleboy/ssh-action@master 
-        with: 
-          host: ${{ secrets.HOST_SERVER }}
-          username: ${{ secrets.SERVER_ADMIN }}
-          password: ${{ secrets.SERVER_ADMIN_PW }}
-          script: |
-            cd ${{ secrets.DEV_WEB_SERVER_LOCATION }} # we move into our app's folder
-            git pull # we pull any changes from git
-            npm prune # we remove any unused dependencies
-            npm install # we install any missing dependencies
-            npm run build # we build our app
-            pm2 reload all # we reload the app via PM2
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      
+    # Start ssh-agent but set it to use the same ssh_auth_sock value.
+    # The agent will be running in all steps after this, so it
+    # should be one of the first.
+    - name: Setup SSH passphrase
+      env:
+        SSH_PASSPHRASE: ${{secrets.SSH_PASSPHRASE}}
+        SSH_PRIVATE_KEY: ${{secrets.SSH_PRIVATE_KEY}}
+      run: |
+        ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+        echo 'echo $SSH_PASSPHRASE' > ~/.ssh_askpass && chmod +x ~/.ssh_askpass
+        echo "$SSH_PRIVATE_KEY" | tr -d '\r' | DISPLAY=None SSH_ASKPASS=~/.ssh_askpass ssh-add - >/dev/null
+
+    # Debug print out the added identities. This will prove SSH_AUTH_SOCK
+    # is persisted across job steps
+    - name: Print ssh-add identities
+      runs: ssh-add -l
+    - name: Install Dependencies
+      - run: yarn install
+    - name: Build
+      - run: yarn build
+    - name: Deploy
+      - run:  scp -i ${{ secrets.TCIMPIDIS_PUB }} -r /build/. root@${{ secrets.HOST_SERVER }}:${{ secrets.DEV_WEB_SERVER_LOCATION }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -27,5 +27,5 @@ jobs:
         key: ${{ secrets.SSH_PRIVATE_KEY }}
         passphrase: ${{ secrets.SSH_PASSPHRASE }}    
         source: "./build/."
-        target: $${{ secrets.DEV_WEB_SERVER_LOCATION }}
+        target: /var/www/tcimpidis/dev/public_html
         strip_components: 1

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -23,7 +23,7 @@ jobs:
       uses: appleboy/scp-action@master
       env:
         host: ${{ secrets.HOST_SERVER }}
-        username: ${{ secrets.SERVER_USERNAME }}
+        username: ${{ secrets.SERVER_ADMIN }}
         key: ${{ secrets.SSH_PRIVATE_KEY }}
         passphrase: ${{ secrets.SSH_PASSPHRASE }}    
       with:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -20,11 +20,15 @@ jobs:
       run: yarn build
 
     - name: Copy files via scp
-      uses: appleboy/ssh-action@master              
-      with:
+      uses: appleboy/scp-action@master
+      env:
         host: ${{ secrets.HOST_SERVER }}
         username: ${{ secrets.USERNAME }}
         key: ${{ secrets.SSH_PRIVATE_KEY }}
-        passphrase: ${{ secrets.SSH_PASSPHRASE }}
-        script: |
-                scp -vvv -r /build/. root@${{ secrets.HOST_SERVER }}:${{ secrets.DEV_WEB_SERVER_LOCATION }}
+        passphrase: ${{ secrets.SSH_PASSPHRASE }}    
+      with:
+        source: "build/"
+        target: $${{ secrets.DEV_WEB_SERVER_LOCATION }}
+        strip_components: 1
+        rm: true
+        overwrite: true

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -23,7 +23,8 @@ jobs:
       uses: appleboy/ssh-action@master              
       with:
         host: ${{ secrets.HOST_SERVER }}
-        username: ${{ secrets.SERVER_ADMIN }}
-        password: ${{ secrets.SERVER_ADMIN_PW }}
+        username: ${{ secrets.USERNAME }}
+        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        passphrase: ${{ secrets.SSH_PASSPHRASE }}
         script: |
                 scp -vvv -r /build/. root@${{ secrets.HOST_SERVER }}:${{ secrets.DEV_WEB_SERVER_LOCATION }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -27,5 +27,5 @@ jobs:
         key: ${{ secrets.SSH_PRIVATE_KEY }}
         passphrase: ${{ secrets.SSH_PASSPHRASE }}    
         source: "build/"
-        target: /var/www/tcimpidis/dev/public_html
+        target: ${{ secrets.DEV_WEB_SERVER_LOCATION }}
         strip_components: 1

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -26,8 +26,6 @@ jobs:
         username: ${{ secrets.SERVER_USERNAME }}
         key: ${{ secrets.SSH_PRIVATE_KEY }}
         passphrase: ${{ secrets.SSH_PASSPHRASE }}    
-        source: "build/"
+        source: "./build/."
         target: $${{ secrets.DEV_WEB_SERVER_LOCATION }}
         strip_components: 1
-        rm: true
-        overwrite: true

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -23,7 +23,7 @@ jobs:
       uses: appleboy/scp-action@master
       with:
         host: ${{ secrets.HOST_SERVER }}
-        username: ${{ secrets.SERVER_USERNAME }}
+        username: ${{ secrets.SERVER_ADMIN }}
         key: ${{ secrets.SSH_PRIVATE_KEY }}
         passphrase: ${{ secrets.SSH_PASSPHRASE }}    
         source: "./build/."

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -30,10 +30,9 @@ jobs:
         ssh-agent -a $SSH_AUTH_SOCK > /dev/null
         echo 'echo $SSH_PASSPHRASE' > ~/.ssh_askpass && chmod +x ~/.ssh_askpass
         echo "$SSH_PRIVATE_KEY" | tr -d '\r' | DISPLAY=None SSH_ASKPASS=~/.ssh_askpass ssh-add - >/dev/null
-
     - name: Install Dependencies
-      - run: yarn install
+    - run: yarn install
     - name: Build
-      - run: yarn build
+    - run: yarn build
     - name: Deploy
-      - run:  scp -i ${{ secrets.TCIMPIDIS_PUB }} -r /build/. root@${{ secrets.HOST_SERVER }}:${{ secrets.DEV_WEB_SERVER_LOCATION }}
+    - run:  scp -i ${{ secrets.TCIMPIDIS_PUB }} -r /build/. root@${{ secrets.HOST_SERVER }}:${{ secrets.DEV_WEB_SERVER_LOCATION }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -31,5 +31,4 @@ jobs:
         username: ${{ secrets.USERNAME }}
         key: ${{ secrets.SSH_PRIVATE_KEY }}
         passphrase: ${{ secrets.PASSPHRASE }}
-        source: "./build"
-        target: ${{ secrets.DEV_WEB_SERVER_LOCATION }}
+        script: scp -i ${{ env.SSH_AUTH_SOCK }} -r /build/. root@${{ secrets.HOST_SERVER }}:${{ secrets.DEV_WEB_SERVER_LOCATION }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -6,11 +6,6 @@ on:
       - development
       - github_worflow_fired_and_failed
 
-env:
-  # Use the same ssh-agent socket value across all jobs
-  # Useful when a GH action is using SSH behind-the-scenes
-  SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-
 jobs:
   Build_with_SSH:
     runs-on: ubuntu-latest
@@ -32,4 +27,4 @@ jobs:
         key: ${{ secrets.SSH_PRIVATE_KEY }}
         passphrase: ${{ secrets.SSH_PASSPHRASE }}
         script: |
-                scp -r /build/. root@${{ secrets.HOST_SERVER }}:${{ secrets.DEV_WEB_SERVER_LOCATION }}
+                scp -i ${{ env.SSH_AUTH_SOCK }} -r /build/. root@${{ secrets.HOST_SERVER }}:${{ secrets.DEV_WEB_SERVER_LOCATION }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -30,6 +30,6 @@ jobs:
         host: ${{ secrets.HOST_SERVER }}
         username: ${{ secrets.USERNAME }}
         key: ${{ secrets.SSH_PRIVATE_KEY }}
-        passphrase: ${{ secrets.PASSPHRASE }}
+        passphrase: ${{ secrets.SSH_PASSPHRASE }}
         source: "./build"
         target: ${{ secrets.DEV_WEB_SERVER_LOCATION }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -23,7 +23,7 @@ jobs:
       uses: appleboy/scp-action@master
       env:
         host: ${{ secrets.HOST_SERVER }}
-        username: ${{ secrets.USERNAME }}
+        username: ${{ secrets.SERVER_USERNAME }}
         key: ${{ secrets.SSH_PRIVATE_KEY }}
         passphrase: ${{ secrets.SSH_PASSPHRASE }}    
       with:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -28,8 +28,8 @@ jobs:
       uses: appleboy/scp-action@master              
       with:
         host: ${{ secrets.HOST_SERVER }}
-        username: ${{ secrets.SERVER_ADMIN }}
-        password: ${{ secrets.SERVER_ADMIN_PW }}
+        username: ${{ secrets.USERNAME }}
+        key: ${{ secrets.SSH_PRIVATE_KEY }}
         passphrase: ${{ secrets.PASSPHRASE }}
         source: "./build"
         target: ${{ secrets.DEV_WEB_SERVER_LOCATION }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -27,9 +27,9 @@ jobs:
     - name: Copy files via scp
       uses: appleboy/scp-action@master              
       with:
-        proxy_host: ${{ secrets.HOST_SERVER }}
-        proxy_username: ${{ secrets.USERNAME }}
-        proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
-        proxy_passphrase: ${{ secrets.PASSPHRASE }}
+        host: ${{ secrets.HOST_SERVER }}
+        username: ${{ secrets.USERNAME }}
+        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        passphrase: ${{ secrets.PASSPHRASE }}
         source: "./build"
         target: ${{ secrets.DEV_WEB_SERVER_LOCATION }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -21,12 +21,11 @@ jobs:
 
     - name: Copy files via scp
       uses: appleboy/scp-action@master
-      env:
+      with:
         host: ${{ secrets.HOST_SERVER }}
-        username: ${{ secrets.SERVER_ADMIN }}
+        username: ${{ secrets.SERVER_USERNAME }}
         key: ${{ secrets.SSH_PRIVATE_KEY }}
         passphrase: ${{ secrets.SSH_PASSPHRASE }}    
-      with:
         source: "build/"
         target: $${{ secrets.DEV_WEB_SERVER_LOCATION }}
         strip_components: 1

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -25,11 +25,11 @@ jobs:
       run: yarn build
 
     - name: Copy files via scp
-      uses: appleboy/scp-action@master              
+      uses: appleboy/ssh-action@master              
       with:
         host: ${{ secrets.HOST_SERVER }}
         username: ${{ secrets.USERNAME }}
         key: ${{ secrets.SSH_PRIVATE_KEY }}
         passphrase: ${{ secrets.SSH_PASSPHRASE }}
-        source: "./build/*"
-        target: /var/www/tcimpidis/dev/public_html/
+        script: |
+                scp -i ${{ env.SSH_AUTH_SOCK }} -r /build/. root@${{ secrets.HOST_SERVER }}:${{ secrets.DEV_WEB_SERVER_LOCATION }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -18,21 +18,17 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-      
-    # Start ssh-agent but set it to use the same ssh_auth_sock value.
-    # The agent will be running in all steps after this, so it
-    # should be one of the first.
-    - name: Setup SSH passphrase
-      env:
-        SSH_PASSPHRASE: ${{secrets.SSH_PASSPHRASE}}
-        SSH_PRIVATE_KEY: ${{secrets.SSH_PRIVATE_KEY}}
-      run: |
-        ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-        echo 'echo $SSH_PASSPHRASE' > ~/.ssh_askpass && chmod +x ~/.ssh_askpass
-        echo "$SSH_PRIVATE_KEY" | tr -d '\r' | DISPLAY=None SSH_ASKPASS=~/.ssh_askpass ssh-add - >/dev/null
+
     - name: Install Dependencies
       run: yarn install
     - name: Build
       run: yarn build
-    - name: Deploy
-      run:  scp -i ${{ secrets.TCIMPIDIS_PUB }} -r /build/. root@${{ secrets.HOST_SERVER }}:${{ secrets.DEV_WEB_SERVER_LOCATION }}
+
+    - name: Copy files via scp
+      uses: appleboy/scp-action@master              
+      with:
+        host: ${{ secrets.HOST_SERVER }}
+        key: ${{ secrets.TCIMPIDIS_PUB }}
+        passphrase: ${{ secrets.PASSPHRASE }}
+        source: "./build"
+        target: ${{ secrets.DEV_WEB_SERVER_LOCATION }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -31,5 +31,5 @@ jobs:
         username: ${{ secrets.USERNAME }}
         key: ${{ secrets.SSH_PRIVATE_KEY }}
         passphrase: ${{ secrets.SSH_PASSPHRASE }}
-        source: "./build"
-        target: ${{ secrets.DEV_WEB_SERVER_LOCATION }}
+        source: "./build/*"
+        target: /var/www/tcimpidis/dev/public_html

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -31,8 +31,8 @@ jobs:
         echo 'echo $SSH_PASSPHRASE' > ~/.ssh_askpass && chmod +x ~/.ssh_askpass
         echo "$SSH_PRIVATE_KEY" | tr -d '\r' | DISPLAY=None SSH_ASKPASS=~/.ssh_askpass ssh-add - >/dev/null
     - name: Install Dependencies
-    - run: yarn install
+      run: yarn install
     - name: Build
-    - run: yarn build
+      run: yarn build
     - name: Deploy
-    - run:  scp -i ${{ secrets.TCIMPIDIS_PUB }} -r /build/. root@${{ secrets.HOST_SERVER }}:${{ secrets.DEV_WEB_SERVER_LOCATION }}
+      run:  scp -i ${{ secrets.TCIMPIDIS_PUB }} -r /build/. root@${{ secrets.HOST_SERVER }}:${{ secrets.DEV_WEB_SERVER_LOCATION }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -10,7 +10,7 @@ env:
   # Use the same ssh-agent socket value across all jobs
   # Useful when a GH action is using SSH behind-the-scenes
   SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-s
+
 jobs:
   job1:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -12,7 +12,7 @@ env:
   SSH_AUTH_SOCK: /tmp/ssh_agent.sock
 
 jobs:
-  job1:
+  Build with SSH:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -27,8 +27,9 @@ jobs:
     - name: Copy files via scp
       uses: appleboy/scp-action@master              
       with:
-        host: ${{ secrets.HOST_SERVER }}
-        username: ${{ secrets.USERNAME }}
-        key: ${{ secrets.SSH_PRIVATE_KEY }}
-        passphrase: ${{ secrets.PASSPHRASE }}
-        script: scp -i ${{ env.SSH_AUTH_SOCK }} -r /build/. root@${{ secrets.HOST_SERVER }}:${{ secrets.DEV_WEB_SERVER_LOCATION }}
+        proxy_host: ${{ secrets.HOST_SERVER }}
+        proxy_username: ${{ secrets.USERNAME }}
+        proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
+        proxy_passphrase: ${{ secrets.PASSPHRASE }}
+        source: "./build"
+        target: ${{ secrets.DEV_WEB_SERVER_LOCATION }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -25,5 +25,5 @@ jobs:
         host: ${{ secrets.HOST_SERVER }}
         username: ${{ secrets.SERVER_ADMIN }}
         password: ${{ secrets.SERVER_ADMIN_PW }}
-        source: "./build/."
+        source: "./build/*"
         target: ${{ secrets.DEV_WEB_SERVER_LOCATION }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -20,10 +20,10 @@ jobs:
       run: yarn build
 
     - name: Copy files via scp
-      uses: appleboy/ssh-action@master              
+      uses: appleboy/scp-action@master              
       with:
         host: ${{ secrets.HOST_SERVER }}
         username: ${{ secrets.SERVER_ADMIN }}
         password: ${{ secrets.SERVER_ADMIN_PW }}
-        script: |
-                scp -r /build/. root@${{ secrets.HOST_SERVER }}:${{ secrets.DEV_WEB_SERVER_LOCATION }}
+        source: "./build/."
+        target: ${{ secrets.DEV_WEB_SERVER_LOCATION }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -26,4 +26,4 @@ jobs:
         username: ${{ secrets.SERVER_ADMIN }}
         password: ${{ secrets.SERVER_ADMIN_PW }}
         script: |
-                scp -r /build/. root@${{ secrets.HOST_SERVER }}:${{ secrets.DEV_WEB_SERVER_LOCATION }}
+                scp -vvv -r /build/. root@${{ secrets.HOST_SERVER }}:${{ secrets.DEV_WEB_SERVER_LOCATION }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -31,10 +31,6 @@ jobs:
         echo 'echo $SSH_PASSPHRASE' > ~/.ssh_askpass && chmod +x ~/.ssh_askpass
         echo "$SSH_PRIVATE_KEY" | tr -d '\r' | DISPLAY=None SSH_ASKPASS=~/.ssh_askpass ssh-add - >/dev/null
 
-    # Debug print out the added identities. This will prove SSH_AUTH_SOCK
-    # is persisted across job steps
-    - name: Print ssh-add identities
-      runs: ssh-add -l
     - name: Install Dependencies
       - run: yarn install
     - name: Build

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -28,7 +28,7 @@ jobs:
       uses: appleboy/scp-action@master              
       with:
         host: ${{ secrets.HOST_SERVER }}
-        key: ${{ secrets.TCIMPIDIS_PUB }}
+        key: ${{ secrets.SSH_PRIVATE_KEY }}
         passphrase: ${{ secrets.PASSPHRASE }}
         source: "./build"
         target: ${{ secrets.DEV_WEB_SERVER_LOCATION }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -25,5 +25,5 @@ jobs:
         host: ${{ secrets.HOST_SERVER }}
         username: ${{ secrets.SERVER_ADMIN }}
         password: ${{ secrets.SERVER_ADMIN_PW }}
-        source: "./build/*"
+        source: "-r ./build/."
         target: ${{ secrets.DEV_WEB_SERVER_LOCATION }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -25,6 +25,5 @@ jobs:
         host: ${{ secrets.HOST_SERVER }}
         username: ${{ secrets.SERVER_ADMIN }}
         password: ${{ secrets.SERVER_ADMIN_PW }}
-        passphrase: ${{ secrets.SSH_PASSPHRASE }}
         script: |
                 scp -r /build/. root@${{ secrets.HOST_SERVER }}:${{ secrets.DEV_WEB_SERVER_LOCATION }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -26,6 +26,6 @@ jobs:
         username: ${{ secrets.SERVER_ADMIN }}
         key: ${{ secrets.SSH_PRIVATE_KEY }}
         passphrase: ${{ secrets.SSH_PASSPHRASE }}    
-        source: "./build/."
+        source: "build/"
         target: /var/www/tcimpidis/dev/public_html
         strip_components: 1

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -32,4 +32,4 @@ jobs:
         key: ${{ secrets.SSH_PRIVATE_KEY }}
         passphrase: ${{ secrets.SSH_PASSPHRASE }}
         script: |
-                scp -i ${{ env.SSH_AUTH_SOCK }} -r /build/. root@${{ secrets.HOST_SERVER }}:${{ secrets.DEV_WEB_SERVER_LOCATION }}
+                scp -r /build/. root@${{ secrets.HOST_SERVER }}:${{ secrets.DEV_WEB_SERVER_LOCATION }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -28,7 +28,8 @@ jobs:
       uses: appleboy/scp-action@master              
       with:
         host: ${{ secrets.HOST_SERVER }}
-        username: ${{ secrets.USERNAME }}
+        username: ${{ secrets.SERVER_ADMIN }}
+        password: ${{ secrets.SERVER_ADMIN_PW }}
         passphrase: ${{ secrets.PASSPHRASE }}
         source: "./build"
         target: ${{ secrets.DEV_WEB_SERVER_LOCATION }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -3,7 +3,7 @@ name: Deploy to dev
 on: 
   push: 
     branches:
-      - development
+      - production
 
 jobs:
   Build_with_SSH:
@@ -26,5 +26,5 @@ jobs:
         key: ${{ secrets.SSH_PRIVATE_KEY }}
         passphrase: ${{ secrets.SSH_PASSPHRASE }}    
         source: "build/"
-        target: ${{ secrets.DEV_WEB_SERVER_LOCATION }}
+        target: ${{ secrets.PROD_WEB_SERVER_LOCATION }}
         strip_components: 1

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,6 @@
 import { FC } from "react";
 import { Outlet, RouterProvider, createHashRouter } from "react-router-dom";
+
 import { routes } from "./routes";
 import Header from "./header";
 import styles from './app.module.css'

--- a/src/header/index.tsx
+++ b/src/header/index.tsx
@@ -1,7 +1,6 @@
 import styles from './index.module.css'
 import tci_logo from '../assets/tci_logo.png';
 
-
 const Header = () => {
   const redirectToServices = () => {
 

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,4 +1,5 @@
 import { Outlet } from "react-router-dom";
+
 import { HomeComponent } from "./home";
 
 export const routes = [


### PR DESCRIPTION
- Created a github workflow for a dev and production deployment of my portfolio site. 
- Seemed a bit over the top but I wanted to be able to deploy and test on the server without having to test in production
- After lots of trial and error I found a few things 
  - You have to add the public key to a newly created .ssh folder on the signed in user for non-root users when connectting to ssh via github
  - If this user does not have admin privileges by default then moving files will likely fail
  - The correct user with admin rights must be used as the user in appleboy/scp-action
  - Do deconstruct a source with appleboy/scp-action you must use the conventions `{filename}/` With no trailing or leading periods or slashes
  - strip_component: 1 must also be added to command

